### PR TITLE
meet判定のstationを自動判定するようにテストコード

### DIFF
--- a/.techtrain/manifests/station10.json
+++ b/.techtrain/manifests/station10.json
@@ -1,10 +1,21 @@
 {
     "name": "Station 10",
     "id": 120,
-    "prepare": [],
+    "prepare": [
+        {
+            "command": "yarn run clean-test-result"
+        }
+    ],
     "tests": [
         {
-            "type": "interview"
+            "type": "junit-compat",
+            "command": "yarn",
+            "args": [
+                "run",
+                "run-unit-test",
+                "10"
+            ],
+            "reportFile": "./app/build/test-results/testDebugUnitTest/TEST-com.example.techtrain.railway.S10.xml"
         }
     ]
 }

--- a/.techtrain/manifests/station15.json
+++ b/.techtrain/manifests/station15.json
@@ -1,10 +1,21 @@
 {
     "name": "Station 15",
     "id": 125,
-    "prepare": [],
+    "prepare": [
+        {
+            "command": "yarn run clean-test-result"
+        }
+    ],
     "tests": [
         {
-            "type": "interview"
+            "type": "junit-compat",
+            "command": "yarn",
+            "args": [
+                "run",
+                "run-unit-test",
+                "15"
+            ],
+            "reportFile": "./app/build/test-results/testDebugUnitTest/TEST-com.example.techtrain.railway.S15.xml"
         }
     ]
 }

--- a/.techtrain/manifests/station17.json
+++ b/.techtrain/manifests/station17.json
@@ -1,10 +1,21 @@
 {
     "name": "Station 17",
     "id": 127,
-    "prepare": [],
+    "prepare": [
+        {
+            "command": "yarn run clean-test-result"
+        }
+    ],
     "tests": [
         {
-            "type": "interview"
+            "type": "junit-compat",
+            "command": "yarn",
+            "args": [
+                "run",
+                "run-unit-test",
+                "17"
+            ],
+            "reportFile": "./app/build/test-results/testDebugUnitTest/TEST-com.example.techtrain.railway.S17.xml"
         }
     ]
 }

--- a/app/src/test/java/com/example/techtrain/railway/S10.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S10.kt
@@ -3,7 +3,6 @@ package com.example.techtrain.railway
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
-import android.widget.TextView
 import androidx.core.view.children
 import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -34,7 +33,7 @@ class S10 {
             val contentView = it.findViewById<ViewGroup>(android.R.id.content)
             val rootView = contentView.getChildAt(0) as? ViewGroup
             assertNotNull(rootView, "root viewが見つかりません。")
-            val textViews = rootView.children.toList().filterIsInstance<TextView>()
+            val textViews = rootView.children.toList().filterIsInstance<MaterialTextView>()
             assertEquals(1, textViews.size, "TextViewが存在しないか、複数のTextViewがレイアウト内に存在しています。")
             val editTexts = rootView.children.toList().filterIsInstance<EditText>()
             assertEquals(1, editTexts.size, "EditTextが存在しないか、複数のEditTextがレイアウト内に存在しています。")

--- a/app/src/test/java/com/example/techtrain/railway/S10.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S10.kt
@@ -1,0 +1,79 @@
+package com.example.techtrain.railway
+
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import androidx.core.view.children
+import androidx.test.espresso.intent.Intents
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.techtrain.railway.android.MainActivity
+import com.google.android.material.textview.MaterialTextView
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(AndroidJUnit4::class)
+class S10 {
+
+    @get:Rule
+    val activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun test() {
+        Intents.init()
+        val scenario = activityScenarioRule.scenario
+        scenario.onActivity {
+            val contentView = it.findViewById<ViewGroup>(android.R.id.content)
+            val rootView = contentView.getChildAt(0) as? ViewGroup
+            assertNotNull(rootView, "root viewが見つかりません。")
+            val textViews = rootView.children.toList().filterIsInstance<MaterialTextView>()
+            assertEquals(1, textViews.size, "TextViewが存在しないか、複数のTextViewがレイアウト内に存在しています。")
+            val editTexts = rootView.children.toList().filterIsInstance<EditText>()
+            assertEquals(1, editTexts.size, "EditTextが存在しないか、複数のEditTextがレイアウト内に存在しています。")
+            val buttons = rootView.children.toList().filterIsInstance<Button>()
+            assertEquals(1, buttons.size, "Buttonが存在しないか、複数のButtonがレイアウト内に存在しています。")
+
+            val textView = textViews[0]
+            val editText = editTexts[0]
+            val button = buttons[0]
+
+            val expectedText = "Modified ${System.currentTimeMillis()}"
+            editText.setText(expectedText)
+            button.callOnClick()
+
+            assertEquals(expectedText, textView.text.toString())
+            try {
+                // クラスが存在するかを確認
+                Class.forName("com.example.techtrain.railway.android.databinding.ActivityMainBinding")
+                assertTrue(true)  // クラスが存在する場合
+            } catch (e: ClassNotFoundException) {
+                fail("com.example.techtrain.railway.android.databinding.ActivityMainBinding クラスが見つかりません。")
+            }
+            try {
+                // MainActivityのソースコードパス（パスはプロジェクトの構成により異なります）
+                val mainActivityPath = "src/main/java/com/example/techtrain/railway/android/MainActivity.kt"
+                val path = Paths.get(mainActivityPath)
+
+                // ソースコードを読み込み
+                val content = String(Files.readAllBytes(path))
+
+                // findViewByIdがコード内に含まれていないことを確認
+                if (content.contains("findViewById")) {
+                    fail("MainActivityでfindViewByIdが使用されています。")
+                }
+
+            } catch (e: Exception) {
+                e.printStackTrace()
+                fail("MainActivityのソースコードをチェック中にエラーが発生しました。")
+            }
+        }
+        Intents.release()
+    }
+}

--- a/app/src/test/java/com/example/techtrain/railway/S10.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S10.kt
@@ -3,6 +3,7 @@ package com.example.techtrain.railway
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
+import android.widget.TextView
 import androidx.core.view.children
 import androidx.test.espresso.intent.Intents
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -33,7 +34,7 @@ class S10 {
             val contentView = it.findViewById<ViewGroup>(android.R.id.content)
             val rootView = contentView.getChildAt(0) as? ViewGroup
             assertNotNull(rootView, "root viewが見つかりません。")
-            val textViews = rootView.children.toList().filterIsInstance<MaterialTextView>()
+            val textViews = rootView.children.toList().filterIsInstance<TextView>()
             assertEquals(1, textViews.size, "TextViewが存在しないか、複数のTextViewがレイアウト内に存在しています。")
             val editTexts = rootView.children.toList().filterIsInstance<EditText>()
             assertEquals(1, editTexts.size, "EditTextが存在しないか、複数のEditTextがレイアウト内に存在しています。")

--- a/app/src/test/java/com/example/techtrain/railway/S15.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S15.kt
@@ -9,6 +9,7 @@ import androidx.core.view.children
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.techtrain.railway.android.Book
 import com.example.techtrain.railway.android.MainActivity
 import com.google.android.material.textview.MaterialTextView
 import kotlinx.coroutines.delay
@@ -101,9 +102,21 @@ class S15 {
                     textViews.size,
                     "TextViewが存在しないか、複数のTextViewがレイアウト内に存在しています。"
                 )
-                val result = "[Book(id=b011e918-63a9-4683-ad5d-1bdf87d065e6, title=taikun, url=https://www.yahoo.co.jp/, detail=test, review=tai, reviewer=tai), Book(id=7d8ad2d6-7349-48fe-addb-920fd6917609, title=React, url=https://www.yahoo.co.jp/, detail=ken, review=ken, reviewer=kens), Book(id=2811e448-6491-4324-9c01-1b131c4cca45, title=React, url=https://www.yahoo.co.jp/, detail=test, review=test, reviewer=kens), Book(id=a745e46e-fbd6-4a65-9926-56d33f1ee53a, title=React, url=https://www.yahoo.co.jp/, detail=test, review=test, reviewer=kens), Book(id=1e02b253-dd0a-4378-a4e1-d16417e1d5de, title=Git, url=https://www.yahoo.co.jp/, detail=test, review=test, reviewer=kens), Book(id=c169a916-fa90-4b90-841f-3e2d73302a1e, title=てすと, url=https://www.google.com/?hl=ja, detail=ぐーぐる, review=ぐーぐる, reviewer=na), Book(id=3c714672-c3be-4192-87c9-b09c2ef56d5c, title=ぐーぐる, url=https://www.google.com/?hl=ja, detail=ぐーぐる, review=ぐーぐる, reviewer=na), Book(id=5a29f82b-0de6-42bb-8c6e-1244b28757b2, title=てすと, url=https://www.google.com/?hl=ja, detail=テスト, review=テスト, reviewer=na), Book(id=58b7b376-e4fe-4650-abd7-ccc14da09a5b, title=Getting to Yes, url=https://www.amazon.co.jp/-/en/Roger-Fisher/dp/0143118757, detail=\"Getting to Yes has helped millions of people learn a better way to negotiate. One of the primary business texts of the modern era, it is based on the work of the Harvard Negotiation Project, a group that deals with all levels of negotiation and conflict resolution.\n\nGetting to Yes offers a proven, step-by-step strategy for coming to mutually acceptable agreements in every sort of conflict. Thoroughly updated and revised, it offers readers a straight- forward, universally applicable method for negotiating personal and professional disputes without getting angry-or getting taken.\" -from Amazon.com, review=I have not read this book yet I want to complete in somedays, reviewer=Sugar), Book(id=c39146e8-536a-441f-ad04-47095b1c2696, title=thridweb, url=https://thirdweb.com/, detail=API for web3, review=lets's create somethings new in web3!, reviewer=Sugar)]"
+                // 正規表現を使用して result を Book リストにパースする（簡易的な方法）
+                val bookList = Regex("""Book\(id=([^,]+), title=([^,]+), url=([^,]+), detail=([^,]+), review=([^,]+), reviewer=([^\)]+)\)""")
+                    .findAll(textViews[0].text)
+                    .map { match ->
+                        Book(
+                            id = match.groupValues[1],
+                            title = match.groupValues[2],
+                            url = match.groupValues[3],
+                            detail = match.groupValues[4],
+                            review = match.groupValues[5],
+                            reviewer = match.groupValues[6]
+                        )
+                    }.toList()
                 // テキストビューの内容を確認
-                assertEquals(textViews[0].text, result, "結果が正しくTextViewに表示されていないかoffsetを0から取得していないか")
+                assertTrue(bookList.isNotEmpty(), "結果が正しくTextViewに表示されていないかoffsetを0から取得していないか")
             }
         }
     }

--- a/app/src/test/java/com/example/techtrain/railway/S15.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S15.kt
@@ -5,16 +5,14 @@ import android.app.Application
 import android.content.pm.PackageManager
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.TextView
 import androidx.core.view.children
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.techtrain.railway.android.MainActivity
-import com.google.android.material.textview.MaterialTextView
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
@@ -97,7 +95,7 @@ class S15 {
                 val contentView = it.findViewById<ViewGroup>(android.R.id.content)
                 val rootView = contentView.getChildAt(0) as? ViewGroup
                 assertNotNull(rootView, "root viewが見つかりません。")
-                val textViews = rootView.children.toList().filterIsInstance<MaterialTextView>()
+                val textViews = rootView.children.toList().filterIsInstance<TextView>()
                 assertEquals(
                     1,
                     textViews.size,

--- a/app/src/test/java/com/example/techtrain/railway/S15.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S15.kt
@@ -5,12 +5,12 @@ import android.app.Application
 import android.content.pm.PackageManager
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.TextView
 import androidx.core.view.children
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.techtrain.railway.android.MainActivity
+import com.google.android.material.textview.MaterialTextView
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.fail
@@ -95,7 +95,7 @@ class S15 {
                 val contentView = it.findViewById<ViewGroup>(android.R.id.content)
                 val rootView = contentView.getChildAt(0) as? ViewGroup
                 assertNotNull(rootView, "root viewが見つかりません。")
-                val textViews = rootView.children.toList().filterIsInstance<TextView>()
+                val textViews = rootView.children.toList().filterIsInstance<MaterialTextView>()
                 assertEquals(
                     1,
                     textViews.size,

--- a/app/src/test/java/com/example/techtrain/railway/S15.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S15.kt
@@ -1,0 +1,112 @@
+package com.example.techtrain.railway
+
+import android.Manifest
+import android.app.Application
+import android.content.pm.PackageManager
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.core.view.children
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.techtrain.railway.android.MainActivity
+import com.google.android.material.textview.MaterialTextView
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.reflect.Method
+import kotlin.system.measureTimeMillis
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+
+@RunWith(AndroidJUnit4::class)
+class S15 {
+
+    @get:Rule
+    val activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun test() {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+
+        val info = context.packageManager.getPackageInfo(
+            context.packageName,
+            PackageManager.GET_PERMISSIONS
+        )
+        assertTrue(info.requestedPermissions.toSet().containsAll(setOf(Manifest.permission.INTERNET, Manifest.permission.ACCESS_NETWORK_STATE)), "AndroidManifestに必要なパーミッションが書かれていない")
+
+        val retrofitClass = try {
+            Class.forName("retrofit2.Retrofit")
+        } catch (_: ClassNotFoundException) {
+            null
+        }
+        assertNotNull(retrofitClass, "Retrofitが依存関係に含まれていません。")
+        val moshiConverterFactoryClass = try {
+            Class.forName("retrofit2.converter.moshi.MoshiConverterFactory")
+        } catch (_: ClassNotFoundException) {
+            null
+        }
+        assertNotNull(moshiConverterFactoryClass, "Retrofit converter-moshiが依存関係に含まれていません。")
+
+        try {
+            // BooksService クラスを取得
+            val serviceClass = Class.forName("com.example.techtrain.railway.android.BooksService")
+            assertNotNull(serviceClass, "BooksService クラスが存在しません。")
+
+            // publicBooks メソッドが存在するかを確認
+            val method: Method? = serviceClass.methods.firstOrNull {
+                it.name == "publicBooks" && it.parameterTypes.size == 1 && it.parameterTypes[0] == String::class.java
+            }
+            assertNotNull(method,"BooksService に publicBooks メソッドが存在しません。")
+        } catch (e: ClassNotFoundException) {
+            fail("com.example.techtrain.railway.android.BooksService クラスが見つかりません。")
+        }
+
+        runBlocking {
+            val scenario = activityScenarioRule.scenario
+
+            scenario.onActivity {
+                val contentView = it.findViewById<ViewGroup>(android.R.id.content)
+                val rootView = contentView.getChildAt(0) as? ViewGroup
+                assertNotNull(rootView, "root viewが見つかりません。")
+                val buttons = rootView.children.toList().filterIsInstance<Button>()
+                assertEquals(1, buttons.size, "Buttonが存在しないか、複数のButtonがレイアウト内に存在しています。")
+                // メインスレッドでの処理時間を測定
+                val timeTaken = measureTimeMillis {
+                    // ボタンのクリックをシミュレート
+                    buttons[0].performClick()
+                }
+
+                // メインスレッドがブロックされた場合、一定時間以上かかる
+                if (timeTaken > 100) { // ここでは100msを基準にしています
+                    fail("ボタンのクリックイベントがメインスレッドをブロックしています。")
+                }
+                buttons[0].callOnClick()
+            }
+
+            delay(10000L)
+
+            scenario.onActivity {
+                val contentView = it.findViewById<ViewGroup>(android.R.id.content)
+                val rootView = contentView.getChildAt(0) as? ViewGroup
+                assertNotNull(rootView, "root viewが見つかりません。")
+                val textViews = rootView.children.toList().filterIsInstance<MaterialTextView>()
+                assertEquals(
+                    1,
+                    textViews.size,
+                    "TextViewが存在しないか、複数のTextViewがレイアウト内に存在しています。"
+                )
+                val result = "[Book(id=b011e918-63a9-4683-ad5d-1bdf87d065e6, title=taikun, url=https://www.yahoo.co.jp/, detail=test, review=tai, reviewer=tai), Book(id=7d8ad2d6-7349-48fe-addb-920fd6917609, title=React, url=https://www.yahoo.co.jp/, detail=ken, review=ken, reviewer=kens), Book(id=2811e448-6491-4324-9c01-1b131c4cca45, title=React, url=https://www.yahoo.co.jp/, detail=test, review=test, reviewer=kens), Book(id=a745e46e-fbd6-4a65-9926-56d33f1ee53a, title=React, url=https://www.yahoo.co.jp/, detail=test, review=test, reviewer=kens), Book(id=1e02b253-dd0a-4378-a4e1-d16417e1d5de, title=Git, url=https://www.yahoo.co.jp/, detail=test, review=test, reviewer=kens), Book(id=c169a916-fa90-4b90-841f-3e2d73302a1e, title=てすと, url=https://www.google.com/?hl=ja, detail=ぐーぐる, review=ぐーぐる, reviewer=na), Book(id=3c714672-c3be-4192-87c9-b09c2ef56d5c, title=ぐーぐる, url=https://www.google.com/?hl=ja, detail=ぐーぐる, review=ぐーぐる, reviewer=na), Book(id=5a29f82b-0de6-42bb-8c6e-1244b28757b2, title=てすと, url=https://www.google.com/?hl=ja, detail=テスト, review=テスト, reviewer=na), Book(id=58b7b376-e4fe-4650-abd7-ccc14da09a5b, title=Getting to Yes, url=https://www.amazon.co.jp/-/en/Roger-Fisher/dp/0143118757, detail=\"Getting to Yes has helped millions of people learn a better way to negotiate. One of the primary business texts of the modern era, it is based on the work of the Harvard Negotiation Project, a group that deals with all levels of negotiation and conflict resolution.\n\nGetting to Yes offers a proven, step-by-step strategy for coming to mutually acceptable agreements in every sort of conflict. Thoroughly updated and revised, it offers readers a straight- forward, universally applicable method for negotiating personal and professional disputes without getting angry-or getting taken.\" -from Amazon.com, review=I have not read this book yet I want to complete in somedays, reviewer=Sugar), Book(id=c39146e8-536a-441f-ad04-47095b1c2696, title=thridweb, url=https://thirdweb.com/, detail=API for web3, review=lets's create somethings new in web3!, reviewer=Sugar)]"
+                // テキストビューの内容を確認
+                assertEquals(textViews[0].text, result, "結果が正しくTextViewに表示されていないかoffsetを0から取得していないか")
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/example/techtrain/railway/S17.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S17.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.techtrain.railway.android.MainActivity
+import com.google.android.material.textview.MaterialTextView
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
@@ -76,7 +77,7 @@ class S17 {
                     assertNotNull(itemView,"BookItemViewが見つかりません。")
                     assertEquals("BookItemView", itemView::class.simpleName, "BookItemViewのタイプが一致しません。")
 
-                    val textViews = (itemView as ViewGroup).children.toList().filterIsInstance<TextView>()
+                    val textViews = (itemView as ViewGroup).children.toList().filterIsInstance<MaterialTextView>()
 
                     assertTrue(2 < recyclerViews.size, "TextViewは少なくとも、titleとdetail２個が必要")
                     assertTrue(textViews.map { it.text }.toSet().containsAll(setOf(titleResults[i], detailResults[i])), "${i}番めのtitleとdetailがデータと一致しない")

--- a/app/src/test/java/com/example/techtrain/railway/S17.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S17.kt
@@ -1,6 +1,7 @@
 package com.example.techtrain.railway
 
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -13,6 +14,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class S17 {
@@ -52,6 +54,19 @@ class S17 {
                 // RecyclerViewの各アイテムがBookItemViewであることを確認
                 val titleResults = listOf("taikun", "React", "React", "React", "Git", "てすと", "ぐーぐる", "てすと", "Getting to Yes", "thridweb")
 
+                val detailResults = listOf(
+                    "test",
+                    "ken",
+                    "test",
+                    "test",
+                    "test",
+                    "ぐーぐる",
+                    "ぐーぐる",
+                    "テスト",
+                    "Getting to Yes has helped millions of people learn a better way to negotiate. One of the primary business texts of the modern era, it is based on the work of the Harvard Negotiation Project, a group that deals with all levels of negotiation and conflict resolution. Getting to Yes offers a proven, step-by-step strategy for coming to mutually acceptable agreements in every sort of conflict. Thoroughly updated and revised, it offers readers a straightforward, universally applicable method for negotiating personal and professional disputes without getting angry-or getting taken.",
+                    "API for web3"
+                )
+
                 for (i in 0 until itemCount) {
                     val viewHolder = adapter.createViewHolder(recyclerView, adapter.getItemViewType(i))
                     adapter.bindViewHolder(viewHolder, i)
@@ -60,6 +75,11 @@ class S17 {
                     val itemView = viewHolder.itemView
                     assertNotNull(itemView,"BookItemViewが見つかりません。")
                     assertEquals("BookItemView", itemView::class.simpleName, "BookItemViewのタイプが一致しません。")
+
+                    val textViews = (itemView as ViewGroup).children.toList().filterIsInstance<TextView>()
+
+                    assertTrue(2 < recyclerViews.size, "TextViewは少なくとも、titleとdetail２個が必要")
+                    assertTrue(textViews.map { it.text }.toSet().containsAll(setOf(titleResults[i], detailResults[i])), "${i}番めのtitleとdetailがデータと一致しない")
                 }
             }
         }

--- a/app/src/test/java/com/example/techtrain/railway/S17.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S17.kt
@@ -1,0 +1,67 @@
+package com.example.techtrain.railway
+
+import android.view.ViewGroup
+import androidx.core.view.children
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.techtrain.railway.android.MainActivity
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(AndroidJUnit4::class)
+class S17 {
+
+    @get:Rule
+    val activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun test() {
+        val retrofitClass = try {
+            Class.forName("androidx.recyclerview.widget.RecyclerView")
+        } catch (_: ClassNotFoundException) {
+            null
+        }
+        assertNotNull(retrofitClass, "RecyclerViewが依存関係に含まれていません。")
+        val scenario = activityScenarioRule.scenario
+        runBlocking {
+            delay(10000L)
+            scenario.onActivity {
+                val contentView = it.findViewById<ViewGroup>(android.R.id.content)
+                val rootView = contentView.getChildAt(0) as? ViewGroup
+                assertNotNull(rootView,"root viewが見つかりません。")
+
+                // RecyclerViewのテスト
+                val recyclerViews = rootView.children.toList().filterIsInstance<RecyclerView>()
+                assertEquals(1, recyclerViews.size, "RecyclerViewが存在しないか、複数のRecyclerViewがレイアウト内に存在しています。")
+                val recyclerView = recyclerViews[0]
+                assertNotNull(recyclerView,"RecyclerViewが見つかりません。")
+
+                // RecyclerViewのアダプターを使用してアイテム数を確認
+                val adapter = recyclerView.adapter
+                assertNotNull(adapter,"RecyclerViewのアダプターが設定されていません。")
+
+                // アダプターのアイテム数を確認
+                val itemCount = adapter.itemCount
+                assertEquals( 10, itemCount, "RecyclerViewのアイテム数が正しくありません。")
+                // RecyclerViewの各アイテムがBookItemViewであることを確認
+                val titleResults = listOf("taikun", "React", "React", "React", "Git", "てすと", "ぐーぐる", "てすと", "Getting to Yes", "thridweb")
+
+                for (i in 0 until itemCount) {
+                    val viewHolder = adapter.createViewHolder(recyclerView, adapter.getItemViewType(i))
+                    adapter.bindViewHolder(viewHolder, i)
+
+                    // ViewHolderがBookItemViewを含んでいるか確認
+                    val itemView = viewHolder.itemView
+                    assertNotNull(itemView,"BookItemViewが見つかりません。")
+                    assertEquals("BookItemView", itemView::class.simpleName, "BookItemViewのタイプが一致しません。")
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/example/techtrain/railway/S17.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S17.kt
@@ -53,22 +53,7 @@ class S17 {
                 val itemCount = adapter.itemCount
                 assertEquals( 10, itemCount, "RecyclerViewのアイテム数が正しくありません。")
                 // RecyclerViewの各アイテムがBookItemViewであることを確認
-                val titleResults = listOf("taikun", "React", "React", "React", "Git", "てすと", "ぐーぐる", "てすと", "Getting to Yes", "thridweb")
-
-                val detailResults = listOf(
-                    "test",
-                    "ken",
-                    "test",
-                    "test",
-                    "test",
-                    "ぐーぐる",
-                    "ぐーぐる",
-                    "テスト",
-                    "Getting to Yes has helped millions of people learn a better way to negotiate. One of the primary business texts of the modern era, it is based on the work of the Harvard Negotiation Project, a group that deals with all levels of negotiation and conflict resolution. Getting to Yes offers a proven, step-by-step strategy for coming to mutually acceptable agreements in every sort of conflict. Thoroughly updated and revised, it offers readers a straightforward, universally applicable method for negotiating personal and professional disputes without getting angry-or getting taken.",
-                    "API for web3"
-                )
-
-                for (i in 0 until itemCount) {
+             for (i in 0 until itemCount) {
                     val viewHolder = adapter.createViewHolder(recyclerView, adapter.getItemViewType(i))
                     adapter.bindViewHolder(viewHolder, i)
 
@@ -80,7 +65,7 @@ class S17 {
                     val textViews = (itemView as ViewGroup).children.toList().filterIsInstance<MaterialTextView>()
 
                     assertTrue(2 < recyclerViews.size, "TextViewは少なくとも、titleとdetail２個が必要")
-                    assertTrue(textViews.map { it.text }.toSet().containsAll(setOf(titleResults[i], detailResults[i])), "${i}番めのtitleとdetailがデータと一致しない")
+                    assertTrue(textViews.map { it.text.isEmpty() }.contains(true), "${i}番めのtitleとdetailが入っていない")
                 }
             }
         }


### PR DESCRIPTION
## 共通でstationの最初説明された面談関連の話削除
```
この Station は、クリア判定をメンターとの面談により行います。（複数 Station まとめて行うことが可能です。）
「TechTrain へようこそ」の資料中の [メンターとの面談を活用しよう](https://docs.google.com/presentation/d/1o7pMnYO5hZSAdNwNG93iuMV7GxGFC9Y8OaHxTxctIQ8/edit#slide=id.g2cf696b2606_0_171) ページをよく読んでから面談に挑んでください。
```

## station10
#### 文書修正
取り組む手順
3.面談予約をする。
- このStationでは面談でクリア判定を行うため、Androidメンターから選び、面談予約をしましょう。

4.メンターから合格判定をいただけると、Stationクリアです！

上記3と４を削除

## station15
#### 課題
- API結果がramdom性あり結果正しいか判別ができません
    - とりあえず表示データーがBookのListに適応できるか確認するように具体的内容は検査しない

#### 文書修正
取り組む手順
1.TechTrainのAPI向けのRetrofitのServiceを作成する。
- 該当のAPIのpathは public/books です。
- 本を表すモデルクラス Book が既に準備されているので、それを活用しましょう。
- Call<List<Book>> 型を返す関数として定義すると良いでしょう。
- 以下太字追加
**Serviceのinterfaceクラス名をBooksServiceとする**
**Service クラスは Bookクラスと同じ階層に置く**
2. _MainActivityが表示されたタイミング_ でRetrofitのServiceを経由してデータを取得し、TextViewへ表示させる。
- 斜め文字部分を**MainActivityでボタンのclickされたタイミングで**に変更

3.面談予約をする。
- このStationでは面談でクリア判定を行うため、Androidメンターから選び、面談予約をしましょう。

4.メンターから合格判定をいただけると、Stationクリアです！

上記3と４を削除

## station17
#### 課題
- API結果がramdom性あり結果正しいか判別ができません
    - 当面は判断しないようにnullチェックだけ
- 今までも要求になかったがおそらく見た目の表示はメンターさんがちゃんと普通のUIか確認しているが、「普通のUI」という標準がシステム的テスト難しいしmarginやサイズなど細かく決めるのもコスパ悪い気がする
    - station17の目的はRecycleViewでデータをitemごとに表示することで、UIのところは以前のstationでやり方教えていたし一旦チェックしない方針。
    
#### 文書修正
1.1行ごとのレイアウトファイルを作成する。
- 1行ごとのレイアウトには、本1冊のデータを表示できるようにしましょう
- RecyelerViewでは、この1行のレイアウトを並べて表示することでリスト上に表示をすることができます
- 以下太字追加
 **レイアウトのクラス名をBookItemViewとする**
 **BookItemViewには少なくともtitleとdetail２つの要素を表示する**
 **＊クリア判断のため、BookItemViewに空のTextViewは残さない**


5.面談予約をする。
- このStationでは面談でクリア判定を行うため、Androidメンターから選び、面談予約をしましょう。

6.メンターから合格判定をいただけると、Stationクリアです！
上記5と6を削除