### PR TITLE
sdkバージョン上げることで変なパーミッション混じってエラーになるのを除去

### DIFF
--- a/app/src/test/java/com/example/techtrain/railway/S14.kt
+++ b/app/src/test/java/com/example/techtrain/railway/S14.kt
@@ -22,9 +22,12 @@ class S14 {
             context.packageName,
             PackageManager.GET_PERMISSIONS
         )
+        val requestedPermissions = info.requestedPermissions.filter {
+            it != context.packageName + ".DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"
+        }
         assertEquals(
             setOf(Manifest.permission.INTERNET, Manifest.permission.ACCESS_NETWORK_STATE),
-            info.requestedPermissions.toSet(),
+            requestedPermissions.toSet(),
             "AndroidManifestに必要なパーミッションが書かれていないか、余分なパーミッションが書かれています。"
         )
 


### PR DESCRIPTION
AndroidManifestに必要なパーミッションが書かれていないか、余分なパーミッションが書かれています。
Expected :[android.permission.INTERNET, android.permission.ACCESS_NETWORK_STATE]
Actual   :[android.permission.INTERNET, android.permission.ACCESS_NETWORK_STATE, com.example.techtrain.railway.android.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION]
問題を修正

参考[リンク](https://stackoverflow.com/questions/74146297/android-adding-dynamic-receiver-not-exported-permission-in-release-build/78816850#78816850)